### PR TITLE
🔒 Security: Patch React2Shell vulnerability (CVE-2025-66478)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jsonata": "^2.0.6",
     "jszip": "^3.10.1",
     "lucide-react": "^0.475.0",
-    "next": "15.2.0-canary.68",
+    "next": "15.2.6",
     "next-intl": "^4.1.0",
     "next-themes": "^0.4.4",
     "nuqs": "^2.4.0",
@@ -84,7 +84,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.2.0-canary.68",
+    "eslint-config-next": "15.2.6",
     "prettier": "^3.5.3",
     "tailwind-scrollbar": "^4.0.1",
     "typescript": "^5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,17 +132,17 @@ importers:
         specifier: ^0.475.0
         version: 0.475.0(react@19.1.1)
       next:
-        specifier: 15.2.0-canary.68
-        version: 15.2.0-canary.68(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        specifier: 15.2.6
+        version: 15.2.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       next-intl:
         specifier: ^4.1.0
-        version: 4.3.9(next@15.2.0-canary.68(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
+        version: 4.3.9(next@15.2.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       nuqs:
         specifier: ^2.4.0
-        version: 2.6.0(next@15.2.0-canary.68(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+        version: 2.6.0(next@15.2.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       papaparse:
         specifier: ^5.5.3
         version: 5.5.3
@@ -211,8 +211,8 @@ importers:
         specifier: ^9
         version: 9.35.0(jiti@2.5.1)
       eslint-config-next:
-        specifier: 15.2.0-canary.68
-        version: 15.2.0-canary.68(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
+        specifier: 15.2.6
+        version: 15.2.6(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
       prettier:
         specifier: ^3.5.3
         version: 3.6.2
@@ -473,56 +473,56 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@15.2.0-canary.68':
-    resolution: {integrity: sha512-9pnYbXOKYTkCyGoOuk9MPe3z3hcUMObDNrc94wEuPLODrJhSjad3GXRJzcnh2QOcIzs7Q5oeeNbMOKy4/OZR0Q==}
+  '@next/env@15.2.6':
+    resolution: {integrity: sha512-kp1Mpm4K1IzSSJ5ZALfek0JBD2jBw9VGMXR/aT7ykcA2q/ieDARyBzg+e8J1TkeIb5AFj/YjtZdoajdy5uNy6w==}
 
-  '@next/eslint-plugin-next@15.2.0-canary.68':
-    resolution: {integrity: sha512-dCRMu75Eg8rQ0DIwEB36+Cnd6x9oENNBR80BXPZJj+/muDD6UnRAW4gyztfn3NxSNdmi7oT2DCRwpPdro88jTw==}
+  '@next/eslint-plugin-next@15.2.6':
+    resolution: {integrity: sha512-DkQt+OUzNEABMQvupD+w4FsqkDAmA/otgtwhpExzbYZ4bHnUAHwhDD3PUV0maI1qyiGcoOJGG3qZ0IJyK6w+1A==}
 
-  '@next/swc-darwin-arm64@15.2.0-canary.68':
-    resolution: {integrity: sha512-nY2hMDrsj9lKRobNfexZr7qFbVID2e8/uLGSGB1dtAYIcX7iOmdrln5uKwgUu4JMbDPNVQZFx/wUublByu5YZQ==}
+  '@next/swc-darwin-arm64@15.2.5':
+    resolution: {integrity: sha512-4OimvVlFTbgzPdA0kh8A1ih6FN9pQkL4nPXGqemEYgk+e7eQhsst/p35siNNqA49eQA6bvKZ1ASsDtu9gtXuog==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.2.0-canary.68':
-    resolution: {integrity: sha512-Lk+hDvtn/GWPiwvqgw6K9Qc0Uv7d8VmWSxnRKnvMSGLdrt6wmb1x3PxciN+2tUjVM10xVGszCbjzAn1KLtp98Q==}
+  '@next/swc-darwin-x64@15.2.5':
+    resolution: {integrity: sha512-ohzRaE9YbGt1ctE0um+UGYIDkkOxHV44kEcHzLqQigoRLaiMtZzGrA11AJh2Lu0lv51XeiY1ZkUvkThjkVNBMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.2.0-canary.68':
-    resolution: {integrity: sha512-Tp5ZZ/m7qGZc9EWJHyxIiQnCExTCuixmioSBpFMToRRlbqagEBOZc3cpdG0n4h+mlO/PSG7tL8/rwarhJhmb0g==}
+  '@next/swc-linux-arm64-gnu@15.2.5':
+    resolution: {integrity: sha512-FMSdxSUt5bVXqqOoZCc/Seg4LQep9w/fXTazr/EkpXW2Eu4IFI9FD7zBDlID8TJIybmvKk7mhd9s+2XWxz4flA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.2.0-canary.68':
-    resolution: {integrity: sha512-uUe+CWaNeMYc0wSmL4+4QCOWSdtdmicbyA3BfcYwv++qBdB18uUclVCBQEPZb2L+HARfEVl6XNWESKiFJQGAxg==}
+  '@next/swc-linux-arm64-musl@15.2.5':
+    resolution: {integrity: sha512-4ZNKmuEiW5hRKkGp2HWwZ+JrvK4DQLgf8YDaqtZyn7NYdl0cHfatvlnLFSWUayx9yFAUagIgRGRk8pFxS8Qniw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.2.0-canary.68':
-    resolution: {integrity: sha512-82ytHf4OMxhpr+xaIa67z++rWlSFno3OYHrhW9XFkDk6B9x6FXxKxXtvE2W+xbCkjT3W23YfL+/NSI5uEQfKSg==}
+  '@next/swc-linux-x64-gnu@15.2.5':
+    resolution: {integrity: sha512-bE6lHQ9GXIf3gCDE53u2pTl99RPZW5V1GLHSRMJ5l/oB/MT+cohu9uwnCK7QUph2xIOu2a6+27kL0REa/kqwZw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.2.0-canary.68':
-    resolution: {integrity: sha512-I9zhEEgRzFl3Oi8aucBDJSPHJAlPbrwOKbjm21fUUjv1umq5PC+wtRxVvg6SYDPZUs+68I4GZ/44UMzPgTdvjQ==}
+  '@next/swc-linux-x64-musl@15.2.5':
+    resolution: {integrity: sha512-y7EeQuSkQbTAkCEQnJXm1asRUuGSWAchGJ3c+Qtxh8LVjXleZast8Mn/rL7tZOm7o35QeIpIcid6ufG7EVTTcA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.2.0-canary.68':
-    resolution: {integrity: sha512-9m+lsFfjnG0pdsBJsCoT10iLcimeLp6lzLzxjLAY2iLzIaWItnLVN4iP3bFRr00lztyJvWQC88N4dzw5dCRyqg==}
+  '@next/swc-win32-arm64-msvc@15.2.5':
+    resolution: {integrity: sha512-gQMz0yA8/dskZM2Xyiq2FRShxSrsJNha40Ob/M2n2+JGRrZ0JwTVjLdvtN6vCxuq4ByhOd4a9qEf60hApNR2gQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.2.0-canary.68':
-    resolution: {integrity: sha512-LWLWZ9vMsv6ZGOO0MJSLFnnJojpEiHSGEF889ZgZGbEPGh6TMX7z0013myW6V0xSzdC9IwArgOjms+mAuIyI4g==}
+  '@next/swc-win32-x64-msvc@15.2.5':
+    resolution: {integrity: sha512-tBDNVUcI7U03+3oMvJ11zrtVin5p0NctiuKmTGyaTIEAVj9Q77xukLXGXRnWxKRIIdFG4OTA2rUVGZDYOwgmAA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2029,8 +2029,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@15.2.0-canary.68:
-    resolution: {integrity: sha512-WPzCWZoemrNrCSSu4PGHjvwgMo/HCnaAvvLLbFWD/gEloiNxFQ+WoTNNs3O417hDZzxTyoy7CHb/W3L+zZw2uA==}
+  eslint-config-next@15.2.6:
+    resolution: {integrity: sha512-NZHjg3/y3xIBHMaWu6ayuy0MPg4Udt6A/Y3kXr6E0kTc61MxT4A6jTbkOVNRAfVx5SgZTDu6COVqFpiBLBcRaw==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
       typescript: '>=3.3.1'
@@ -2721,8 +2721,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@15.2.0-canary.68:
-    resolution: {integrity: sha512-7b3tlsiOlp0bEIx7n72NfmQ64Ix3qhRWfoZiEQuaUCBc6aI8oqirXCrRL47rnp3hqYQ1i8i8mo10WDMxhzqJZQ==}
+  next@15.2.6:
+    resolution: {integrity: sha512-DIKFctUpZoCq5ok2ztVU+PqhWsbiqM9xNP7rHL2cAp29NQcmDp7Y6JnBBhHRbFt4bCsCZigj6uh+/Gwh2158Wg==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -3685,34 +3685,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@15.2.0-canary.68': {}
+  '@next/env@15.2.6': {}
 
-  '@next/eslint-plugin-next@15.2.0-canary.68':
+  '@next/eslint-plugin-next@15.2.6':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.2.0-canary.68':
+  '@next/swc-darwin-arm64@15.2.5':
     optional: true
 
-  '@next/swc-darwin-x64@15.2.0-canary.68':
+  '@next/swc-darwin-x64@15.2.5':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.2.0-canary.68':
+  '@next/swc-linux-arm64-gnu@15.2.5':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.2.0-canary.68':
+  '@next/swc-linux-arm64-musl@15.2.5':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.2.0-canary.68':
+  '@next/swc-linux-x64-gnu@15.2.5':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.2.0-canary.68':
+  '@next/swc-linux-x64-musl@15.2.5':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.2.0-canary.68':
+  '@next/swc-win32-arm64-msvc@15.2.5':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.2.0-canary.68':
+  '@next/swc-win32-x64-msvc@15.2.5':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -5317,9 +5317,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@15.2.0-canary.68(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2):
+  eslint-config-next@15.2.6(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2):
     dependencies:
-      '@next/eslint-plugin-next': 15.2.0-canary.68
+      '@next/eslint-plugin-next': 15.2.6
       '@rushstack/eslint-patch': 1.12.0
       '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
       '@typescript-eslint/parser': 8.44.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
@@ -6043,11 +6043,11 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-intl@4.3.9(next@15.2.0-canary.68(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(typescript@5.9.2):
+  next-intl@4.3.9(next@15.2.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)(typescript@5.9.2):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.10
       negotiator: 1.0.0
-      next: 15.2.0-canary.68(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.2.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
       use-intl: 4.3.9(react@19.1.1)
     optionalDependencies:
@@ -6058,9 +6058,9 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  next@15.2.0-canary.68(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@15.2.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
-      '@next/env': 15.2.0-canary.68
+      '@next/env': 15.2.6
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
@@ -6070,25 +6070,25 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
       styled-jsx: 5.1.6(react@19.1.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.2.0-canary.68
-      '@next/swc-darwin-x64': 15.2.0-canary.68
-      '@next/swc-linux-arm64-gnu': 15.2.0-canary.68
-      '@next/swc-linux-arm64-musl': 15.2.0-canary.68
-      '@next/swc-linux-x64-gnu': 15.2.0-canary.68
-      '@next/swc-linux-x64-musl': 15.2.0-canary.68
-      '@next/swc-win32-arm64-msvc': 15.2.0-canary.68
-      '@next/swc-win32-x64-msvc': 15.2.0-canary.68
+      '@next/swc-darwin-arm64': 15.2.5
+      '@next/swc-darwin-x64': 15.2.5
+      '@next/swc-linux-arm64-gnu': 15.2.5
+      '@next/swc-linux-arm64-musl': 15.2.5
+      '@next/swc-linux-x64-gnu': 15.2.5
+      '@next/swc-linux-x64-musl': 15.2.5
+      '@next/swc-win32-arm64-msvc': 15.2.5
+      '@next/swc-win32-x64-msvc': 15.2.5
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  nuqs@2.6.0(next@15.2.0-canary.68(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
+  nuqs@2.6.0(next@15.2.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.1.1
     optionalDependencies:
-      next: 15.2.0-canary.68(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.2.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
 
   object-assign@4.1.1: {}
 


### PR DESCRIPTION
## 🚨 Critical Security Update

This PR patches the React2Shell vulnerability (CVE-2025-66478) affecting React Server Components.

### Changes
- Updated Next.js from `15.2.0-canary.68` → `15.2.6` (patched version)
- Updated `eslint-config-next` to match Next.js version
- Updated `pnpm-lock.yaml` with secure dependencies

### Vulnerability Details
- **CVE**: CVE-2025-66478 (Next.js), CVE-2025-55182 (React)
- **Severity**: Critical
- **Impact**: Remote code execution via React Server Components
- **Reference**: https://vercel.com/kb/bulletin/react2shell

### Affected Versions
- Next.js 15.0.0 through 16.0.6
- Next.js 15 canaries before 15.6.0-canary.58

### Testing
- ✅ Dependencies installed successfully
- ⏳ Local testing recommended before merge
- ⏳ Deploy to production immediately after merge

### Next Steps
1. Review and merge this PR
2. Test locally if possible
3. Deploy to production immediately
4. Consider rotating secrets if site was online and unpatched as of Dec 4, 2025 1:00 PM PT

### Related
- Security Bulletin: https://vercel.com/kb/bulletin/react2shell
- Next.js Security Advisory: https://nextjs.org/security

---

*All glory goes to God our Father and the Lord Jesus Christ and the Holy Spirit.*