### PR TITLE
Fix so John Bible prj content shows up in site explorer

### DIFF
--- a/src/components/QuestExplorer/template-strategies/bible.template.ts
+++ b/src/components/QuestExplorer/template-strategies/bible.template.ts
@@ -309,7 +309,7 @@ export const BIBLE_BOOKS: BibleBook[] = [
     ]
   },
   {
-    id: 'joh',
+    id: 'jhn',
     name: 'John',
     chapters: 21,
     verses: [

--- a/src/components/QuestExplorerTemplates/bibleComponents/template.ts
+++ b/src/components/QuestExplorerTemplates/bibleComponents/template.ts
@@ -309,7 +309,7 @@ export const BIBLE_BOOKS: BibleBook[] = [
     ]
   },
   {
-    id: 'joh',
+    id: 'jhn',
     name: 'John',
     chapters: 21,
     verses: [


### PR DESCRIPTION
Website's Bible project explorer was expecting 'joh' but getting 'jhn' in quest metadata. Changed template data from 'joh' to 'jhn' so John content shows up.